### PR TITLE
refactor: extract download state aggregator

### DIFF
--- a/apps/backend-electron/src/services/DownloadStateAggregator.ts
+++ b/apps/backend-electron/src/services/DownloadStateAggregator.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from "node:events";
+import { provide } from "@inversifyjs/binding-decorators";
+import { DownloadStatus } from "@mediago/shared-common";
+import { injectable } from "inversify";
+import _ from "lodash";
+
+export interface DownloadItemState {
+  id: number;
+  status: DownloadStatus;
+  progress: number;
+  isLive?: boolean;
+  messages: string[];
+  name?: string;
+  speed?: string;
+}
+
+export interface DownloadState {
+  [key: number]: DownloadItemState;
+}
+
+type DownloadStateListener = (state: DownloadState) => void;
+
+@injectable()
+@provide()
+export default class DownloadStateAggregator {
+  private readonly downloadState: DownloadState = {};
+
+  private lastSentState: DownloadState = {};
+
+  private readonly pendingUpdates = new Set<number>();
+
+  private readonly emitter = new EventEmitter();
+
+  private readonly THROTTLE_TIME = 300;
+
+  private readonly PROGRESS_THRESHOLD = 1;
+
+  private readonly sendStateUpdate: () => void;
+
+  constructor() {
+    this.sendStateUpdate = _.throttle(this.sendBatchStateUpdate.bind(this), this.THROTTLE_TIME);
+  }
+
+  onStateChange(listener: DownloadStateListener): () => void {
+    this.emitter.on("state-change", listener);
+
+    return () => {
+      this.emitter.off("state-change", listener);
+    };
+  }
+
+  updateState(id: number, updates: Partial<DownloadItemState>) {
+    if (!this.downloadState[id]) {
+      this.downloadState[id] = {
+        id,
+        status: DownloadStatus.Ready,
+        progress: 0,
+        messages: [],
+      };
+    }
+
+    this.downloadState[id] = {
+      ...this.downloadState[id],
+      ...updates,
+    };
+
+    if (this.hasSignificantChange(id, updates)) {
+      this.pendingUpdates.add(id);
+      this.sendStateUpdate();
+    }
+  }
+
+  appendMessage(id: number, message: string) {
+    const messages = this.downloadState[id]?.messages ?? [];
+    this.updateState(id, { messages: [...messages, message] });
+  }
+
+  cleanupState(id: number) {
+    if (this.downloadState[id]) {
+      delete this.downloadState[id];
+      delete this.lastSentState[id];
+      this.pendingUpdates.add(id);
+      this.sendStateUpdate();
+    }
+  }
+
+  getSnapshot(): DownloadState {
+    return { ...this.downloadState };
+  }
+
+  private hasSignificantChange(id: number, updates: Partial<DownloadItemState>): boolean {
+    const current = this.downloadState[id];
+    const lastSent = this.lastSentState[id];
+
+    if (updates.status !== undefined && updates.status !== current?.status) {
+      return true;
+    }
+
+    if (updates.isLive !== undefined && updates.isLive !== current?.isLive) {
+      return true;
+    }
+
+    if (updates.progress !== undefined && lastSent) {
+      const progressDiff = Math.abs(updates.progress - (lastSent.progress || 0));
+      if (progressDiff >= this.PROGRESS_THRESHOLD) {
+        return true;
+      }
+    }
+
+    if (updates.progress !== undefined && !lastSent) {
+      return true;
+    }
+
+    if (updates.messages !== undefined) {
+      const currentMsgCount = current?.messages?.length || 0;
+      const newMsgCount = updates.messages.length;
+      return newMsgCount > currentMsgCount;
+    }
+
+    return false;
+  }
+
+  private sendBatchStateUpdate() {
+    if (this.pendingUpdates.size === 0) return;
+
+    const updatedState: DownloadState = { ...this.downloadState };
+
+    if (this.pendingUpdates.size > 0) {
+      this.emitter.emit("state-change", updatedState);
+      this.lastSentState = { ...updatedState };
+    }
+
+    this.pendingUpdates.clear();
+  }
+}

--- a/apps/backend-electron/src/windows/MainWindow.ts
+++ b/apps/backend-electron/src/windows/MainWindow.ts
@@ -8,34 +8,18 @@ import { inject, injectable } from "inversify";
 import _ from "lodash";
 import Window from "../core/window";
 import { isWin } from "../helper/variables";
+import DownloadStateAggregator, {
+  type DownloadState,
+} from "../services/DownloadStateAggregator";
 import ElectronLogger from "../vendor/ElectronLogger";
 import ElectronStore from "../vendor/ElectronStore";
-
-interface DownloadItemState {
-  id: number;
-  status: DownloadStatus;
-  progress: number;
-  isLive?: boolean;
-  messages: string[];
-  name?: string;
-  speed?: string;
-}
-
-interface DownloadState {
-  [key: number]: DownloadItemState;
-}
 
 @injectable()
 @provide()
 export default class MainWindow extends Window {
   url = isDev ? "http://localhost:8555/" : "mediago://index.html/";
   private initialUrl: string | null = null;
-  private downloadState: DownloadState = {};
-  private lastSentState: DownloadState = {}; // 记录上次发送的状态
-  private pendingUpdates = new Set<number>(); // 待处理的更新队列
-  private readonly THROTTLE_TIME = 300; // 减少到 300ms 以提高响应性
-  private readonly PROGRESS_THRESHOLD = 1; // 进度变化阈值 1%
-  private sendStateUpdate: () => void; // 节流函数
+  private readonly unsubscribeDownloadState: () => void;
 
   constructor(
     @inject(ElectronLogger)
@@ -46,6 +30,8 @@ export default class MainWindow extends Window {
     private readonly videoRepository: VideoRepository,
     @inject(ElectronStore)
     private readonly store: ElectronStore,
+    @inject(DownloadStateAggregator)
+    private readonly downloadStateAggregator: DownloadStateAggregator,
   ) {
     super({
       width: 1100,
@@ -68,92 +54,19 @@ export default class MainWindow extends Window {
     this.taskQueue.on("download-message", this.onDownloadMessage);
     this.store.onDidAnyChange(this.storeChange);
 
-    // 使用节流函数定期发送状态更新，并添加批量处理
-    this.sendStateUpdate = _.throttle(this.sendBatchStateUpdate.bind(this), this.THROTTLE_TIME);
+    this.unsubscribeDownloadState = this.downloadStateAggregator.onStateChange(
+      this.sendDownloadStateUpdate,
+    );
   }
 
-  // 检查状态是否有实质性变化
-  private hasSignificantChange = (id: number, updates: Partial<DownloadItemState>): boolean => {
-    const current = this.downloadState[id];
-    const lastSent = this.lastSentState[id];
-
-    // 状态变化总是需要发送
-    if (updates.status !== undefined && updates.status !== current?.status) {
-      return true;
-    }
-
-    // 实时流状态变化需要发送
-    if (updates.isLive !== undefined && updates.isLive !== current?.isLive) {
-      return true;
-    }
-
-    // 进度变化超过阈值才发送
-    if (updates.progress !== undefined && lastSent) {
-      const progressDiff = Math.abs(updates.progress - (lastSent.progress || 0));
-      if (progressDiff >= this.PROGRESS_THRESHOLD) {
-        return true;
-      }
-    }
-
-    // 首次进度更新
-    if (updates.progress !== undefined && !lastSent) {
-      return true;
-    }
-
-    // 消息更新（但需要检查是否真的有新消息）
-    if (updates.messages !== undefined) {
-      const currentMsgCount = current?.messages?.length || 0;
-      const newMsgCount = updates.messages.length;
-      return newMsgCount > currentMsgCount;
-    }
-
-    return false;
-  };
-
-  // 批量发送状态更新
-  private sendBatchStateUpdate = () => {
-    if (this.pendingUpdates.size === 0) return;
-
-    // 发送当前完整的状态，包括清理信息
-    const updatedState: DownloadState = { ...this.downloadState };
-
-    // 如果有状态需要更新，发送完整的当前状态
-    if (this.pendingUpdates.size > 0) {
-      this.send("download-state-update", updatedState);
-
-      // 更新已发送状态的记录
-      this.lastSentState = { ...updatedState };
-    }
-
-    // 清空待处理队列
-    this.pendingUpdates.clear();
-  };
-
-  private updateDownloadState = (id: number, updates: Partial<DownloadItemState>) => {
-    if (!this.downloadState[id]) {
-      this.downloadState[id] = {
-        id,
-        status: DownloadStatus.Ready,
-        progress: 0,
-        messages: [],
-      };
-    }
-
-    this.downloadState[id] = {
-      ...this.downloadState[id],
-      ...updates,
-    };
-
-    // 检查是否有实质性变化
-    if (this.hasSignificantChange(id, updates)) {
-      this.pendingUpdates.add(id);
-      this.sendStateUpdate();
-    }
+  private sendDownloadStateUpdate = (state: DownloadState) => {
+    this.send("download-state-update", state);
   };
 
   closeMainWindow = () => {
     const { closeMainWindow } = this.store.store;
     if (closeMainWindow) {
+      this.unsubscribeDownloadState();
       app.quit();
     }
   };
@@ -161,7 +74,7 @@ export default class MainWindow extends Window {
   onDownloadReadyStart = async ({ id, isLive }: DownloadProgress) => {
     if (isLive) {
       await this.videoRepository.changeVideoIsLive(id);
-      this.updateDownloadState(id, { isLive });
+      this.downloadStateAggregator.updateState(id, { isLive });
     }
   };
 
@@ -225,31 +138,22 @@ export default class MainWindow extends Window {
   };
 
   onDownloadProgress = (progress: DownloadProgress) => {
-    this.updateDownloadState(progress.id, {
+    this.downloadStateAggregator.updateState(progress.id, {
       progress: Number(progress.percent) || 0,
       speed: progress.speed,
       isLive: progress.isLive,
     });
   };
 
-  private cleanupDownloadState = (id: number) => {
-    if (this.downloadState[id]) {
-      delete this.downloadState[id];
-      delete this.lastSentState[id]; // 同时清理发送状态记录
-      this.pendingUpdates.add(id); // 标记需要发送清理状态
-      this.sendStateUpdate();
-    }
-  };
-
   onDownloadSuccess = async (id: number) => {
     this.logger.info(`taskId: ${id} success`);
     await this.videoRepository.changeVideoStatus(id, DownloadStatus.Success);
-    this.updateDownloadState(id, { status: DownloadStatus.Success });
+    this.downloadStateAggregator.updateState(id, { status: DownloadStatus.Success });
 
     const promptTone = this.store.get("promptTone");
     if (promptTone) {
       const video = await this.videoRepository.findVideo(id);
-      this.updateDownloadState(id, { name: video.name });
+      this.downloadStateAggregator.updateState(id, { name: video.name });
 
       new Notification({
         title: i18n.t("downloadSuccess"),
@@ -261,14 +165,14 @@ export default class MainWindow extends Window {
 
     // 延迟清理状态，确保前端有足够时间处理最后的成功状态
     setTimeout(() => {
-      this.cleanupDownloadState(id);
+      this.downloadStateAggregator.cleanupState(id);
     }, 5000);
   };
 
   onDownloadFailed = async (id: number, err: unknown) => {
     this.logger.info(`taskId: ${id} failed`, err);
     await this.videoRepository.changeVideoStatus(id, DownloadStatus.Failed);
-    this.updateDownloadState(id, { status: DownloadStatus.Failed });
+    this.downloadStateAggregator.updateState(id, { status: DownloadStatus.Failed });
 
     const promptTone = this.store.get("promptTone");
     if (promptTone) {
@@ -281,24 +185,24 @@ export default class MainWindow extends Window {
 
     // 延迟清理状态，确保前端有足够时间处理最后的失败状态
     setTimeout(() => {
-      this.cleanupDownloadState(id);
+      this.downloadStateAggregator.cleanupState(id);
     }, 5000);
   };
 
   onDownloadStart = async (id: number) => {
     this.logger.info(`taskId: ${id} start`);
     await this.videoRepository.changeVideoStatus(id, DownloadStatus.Downloading);
-    this.updateDownloadState(id, { status: DownloadStatus.Downloading });
+    this.downloadStateAggregator.updateState(id, { status: DownloadStatus.Downloading });
   };
 
   onDownloadStop = async (id: number) => {
     this.logger.info(`taskId: ${id} stopped`);
     await this.videoRepository.changeVideoStatus(id, DownloadStatus.Stopped);
-    this.updateDownloadState(id, { status: DownloadStatus.Stopped });
+    this.downloadStateAggregator.updateState(id, { status: DownloadStatus.Stopped });
 
     // 延迟清理状态，确保前端有足够时间处理最后的停止状态
     setTimeout(() => {
-      this.cleanupDownloadState(id);
+      this.downloadStateAggregator.cleanupState(id);
     }, 5000);
   };
 
@@ -306,9 +210,7 @@ export default class MainWindow extends Window {
     await this.videoRepository.appendDownloadLog(id, message);
     const showTerminal = this.store.get("showTerminal");
     if (showTerminal) {
-      this.updateDownloadState(id, {
-        messages: [...(this.downloadState[id]?.messages || []), message],
-      });
+      this.downloadStateAggregator.appendMessage(id, message);
     }
   };
 


### PR DESCRIPTION
## Summary
- add a DownloadStateAggregator service to own download state tracking and throttled emission
- update MainWindow to consume the aggregator for all download lifecycle events

## Testing
- pnpm --filter backend-electron types

------
https://chatgpt.com/codex/tasks/task_e_68d283972984832b8ef678a69a9613c7